### PR TITLE
Optional base attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ feed:
   limit: 20
 ```
 
+Optionally you can add `base`:
+
+``` yaml
+feed:
+  base: https://yourdomain.com/subfolder/
+```
+
+- **base** - Post URL base. It might be useful for web sites in subfolders (optional).
 - **type** - Feed type. (atom/rss2. Default: atom).
 - **path** - Feed path. (Default: atom.xml/rss2.xml).
 - **limit** - Maximum number of posts in the feed (Use `0` or `false` to show all posts. Default: 20).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install hexo-generator-multilingual-feed --save
 
 ## Options
 
-You can configure this plugin in `_config.yml`.
+You can configure this plugin in `_config.yml`:
 
 ``` yaml
 feed:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ feed:
   base: https://yourdomain.com/subfolder/
 ```
 
-- **base** - Post URL base. It might be useful for web sites in subfolders (optional).
-- **type** - Feed type. (atom/rss2. Default: atom).
-- **path** - Feed path. (Default: atom.xml/rss2.xml).
-- **limit** - Maximum number of posts in the feed (Use `0` or `false` to show all posts. Default: 20).
+- **base** — Post URL base. It might be useful for web sites in subfolders (optional).
+- **type** — Feed type. (atom/rss2. Default: atom).
+- **path** — Feed path. (Default: atom.xml/rss2.xml).
+- **limit** — Maximum number of posts in the feed (Use `0` or `false` to show all posts. Default: 20).
 
 ### Localizable configuration
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -39,7 +39,7 @@ module.exports = function(locals) {
       });
       if (feedLimit) posts = posts.limit(feedLimit);
 
-      var url = config.url + '/';
+      var url = (config.feed.base ? config.feed.base : config.url + '/');
       url = url.replace(/([^:])\/\//g, '$1/');
 
       var xml = template.render({


### PR DESCRIPTION
Hi, @ahaasler!

Thanks for your plugin, it works like a charm!

I faced a problem when I placed my website to a subfolder. Some plugins and themes don't work correctly when `config.url` contains subfolder, so I have to set `url` without subfolder:

``` yaml
url: https://domain.com
root: /blog/
```

It works perfectly with my plugins and themes, but RSS feed contains wrong URL. So I suggest adding optional `base` attribute to the config:

``` yaml
feed:
  base: https://domain.com/blog/
  type: atom
  path: rss.xml
```

Also, it might be useful when you're migrating your website (so use `base` as canonical address).

Thanks!